### PR TITLE
Use CDPATH if set

### DIFF
--- a/functions/_enhancd_source_history.fish
+++ b/functions/_enhancd_source_history.fish
@@ -6,5 +6,12 @@ function _enhancd_source_history
         return 0
     end
 
+    if test -n "$CDPATH"
+        _enhancd_command_awk \
+            -f "$ENHANCD_ROOT/lib/cdpath.awk" \
+            -v cdpath="$CDPATH" \
+            -v dir="$dir" && return 0
+     end
+
     _enhancd_history_list "$dir"
 end

--- a/functions/enhancd/lib/cdpath.awk
+++ b/functions/enhancd/lib/cdpath.awk
@@ -1,0 +1,11 @@
+BEGIN {
+    n = split(cdpath, array, ":")
+    for (i = 1; i <= n; i++) {
+        path = array[i] "/" dir
+        if (! system("test -d " path )) {
+          print path
+          exit 0
+        }
+    }
+    exit 1
+}

--- a/src/sources.sh
+++ b/src/sources.sh
@@ -51,5 +51,9 @@ __enhancd::sources::history()
     return 0
   fi
 
+  if [[ -n $CDPATH  ]]; then
+    __enhancd::command::awk -f "${ENHANCD_ROOT}/functions/enhancd/lib/cdpath.awk" -v cdpath="${CDPATH}" -v dir="${dir}" && return 0
+  fi
+
   __enhancd::history::list "${dir}"
 }


### PR DESCRIPTION
## WHAT

Make enhancd aware of the `CDPATH`.

## WHY

Currently when cd'ing with a folder that exists under the current current working directory enhancd enters that directory instead of pulling up the history widget. This change extends that to also check if the folder is under any of the paths listed in `CDPATH`, and enters the first found and skips the history widget.